### PR TITLE
Adds run repros to the bot

### DIFF
--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -351,6 +351,11 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
         await triggerGHActionWithComment(request, "sync-branch", {
             branch_name: branch
         }, `sync \`${branch}\` with master`);
+    }, undefined, false))
+    .set(/run repros/, action(async (request, match) => {
+        const issueNumber = request.issue && request.issue.number 
+        const prNumber = request.pull_request && request.pull_request.number 
+        await triggerGHActionWithComment(request, "run-twoslash-repros", { number: issueNumber || prNumber || undefined }, `run the code sample repros`);
     }, undefined, false));
 
 module.exports = async function (context, data) {


### PR DESCRIPTION
Hooks up to the run [twoslash repros action](https://github.com/microsoft/TypeScript/blob/master/.github/workflows/twoslash-repros.yaml#L9) and passes along the number to focus on

```yml

on:
  push:
  schedule:
    - cron:  '0 8 * * *'
  repository_dispatch:
    types: run-twoslash-repros

```

