### PR TITLE
Updated devops-api, fix inline parameters

### DIFF
--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -104,7 +104,7 @@ async function triggerBuild(request, pr, definitionId, buildTriggerAugmentor = p
     const requestingUser = request.comment.user.login;
 
     
-    let buildParams = /** @type BuildVars & { templateParams: object } */ (await buildTriggerAugmentor({
+    let buildParams = /** @type BuildVars & { templateParameters: object } */ (await buildTriggerAugmentor({
         definition: { id: definitionId },
         queue: { id: 11 },
         project: { id: "cf7ac146-d525-443c-b23c-0d58337efebc" },
@@ -112,7 +112,7 @@ async function triggerBuild(request, pr, definitionId, buildTriggerAugmentor = p
         sourceVersion: ``, // Also undocumented
         parameters: JSON.stringify({ source_issue: pr.number, requesting_user: requestingUser }), // This API is real bad
     }));
-    buildParams.templateParams = JSON.parse(buildParams.parameters);
+    buildParams.templateParameters = JSON.parse(buildParams.parameters);
 
     return await build.queueBuild(buildParams, project ?? "TypeScript");
 }

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -295,9 +295,7 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
                     ...JSON.parse(p.parameters),
                     post_result: true,
                     old_ts_repo_url: pr.base.repo.clone_url,
-                    old_head_ref: pr.base.ref,
-                    new_ts_repo_url: pr.head.repo.clone_url,
-                    new_head_ref: pr.head.ref
+                    old_head_ref: pr.base.ref
                 }
             };
         }, getVSTSDevDivClient())))

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -112,11 +112,7 @@ async function triggerBuild(request, pr, definitionId, buildTriggerAugmentor = p
         sourceVersion: ``, // Also undocumented
         parameters: JSON.stringify({ source_issue: pr.number, requesting_user: requestingUser }), // This API is real bad
     }));
-
-    buildParams = {
-        ...buildParams,
-        templateParams: JSON.parse(buildParams.parameters)
-    }
+    buildParams.templateParams = JSON.parse(buildParams.parameters);
 
     return await build.queueBuild(buildParams, project ?? "TypeScript");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,15 @@
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
       "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
     },
+    "azure-devops-node-api": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.0.0.tgz",
+      "integrity": "sha512-hbcOqIucM5vxx0u89E9klSJ1D5aHaTwrgFujpD2AjlLa95JeokAWL4d6y9bs+7hwtcslb79syTzqT+uQfUXAjA==",
+      "requires": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
     "before-after-hook": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
@@ -119,6 +128,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -159,6 +177,21 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -166,6 +199,19 @@
       "requires": {
         "pump": "^3.0.0"
       }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "is-plain-object": {
       "version": "3.0.0",
@@ -228,6 +274,11 @@
         "path-key": "^2.0.0"
       }
     },
+    "object-inspect": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+    },
     "octokit-pagination-methods": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
@@ -269,6 +320,14 @@
         "once": "^1.3.1"
       }
     },
+    "qs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -287,6 +346,16 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -298,23 +367,24 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+      "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
       "requires": {
-        "tunnel": "0.0.4",
-        "underscore": "1.8.3"
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
       }
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "universal-user-agent": {
       "version": "4.0.0",
@@ -322,16 +392,6 @@
       "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
       "requires": {
         "os-name": "^3.1.0"
-      }
-    },
-    "vso-node-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
-      "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
-      "requires": {
-        "tunnel": "0.0.4",
-        "typed-rest-client": "^0.12.0",
-        "underscore": "1.8.3"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "license": "SEE LICENSE IN ASSOCIATED REPO",
   "dependencies": {
     "@octokit/rest": "^16",
-    "vso-node-api": "^6.5.0"
+    "azure-devops-node-api": "^11.0.0"
   }
 }


### PR DESCRIPTION
vso-node-api has been deprecated for some time and doesn't support `templateParameters`. Updated to `azure-devops-node-api`.

Slight refactor to buildParams.