### PR TITLE
Move 'user test inline'

### DIFF
--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -434,7 +434,7 @@ function matchesCommand(context, body, isPr, authorAssociation) {
     }
     const botCall = "@typescript-bot";
     if (body.indexOf(botCall) !== -1) {
-        context.log(`Bot reference detected on ${1} in '${body}'`);
+        context.log(`Bot reference detected in '${body}'`);
     }
     /** @type {((req: any) => Promise<void>)[]} */
     let results = [];


### PR DESCRIPTION
1. Move 'user test inline' to dev.azure.com/typescript/Typescript with the rest of the pipelines.
2. Add help text when a command is not recognised (or when a command fails, or when no command text is given).