### PR TITLE
Make reply to "test top100" not the same as the user tests

### DIFF
--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -268,7 +268,7 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
             })
         };
     })))
-    .set(/test top100/, action(async (request, log) => await makeNewBuildWithComments(request, "diff-based user code test suite", 47, log, async p => {
+    .set(/test top100/, action(async (request, log) => await makeNewBuildWithComments(request, "diff-based top-repos suite", 47, log, async p => {
         const cli = getGHClient();
         const pr = (await cli.pulls.get({ pull_number: request.issue.number, owner: "microsoft", repo: "TypeScript" })).data;
 


### PR DESCRIPTION
Maybe this was a copy-paste error, but the initial reply is the same as the user test suite, even though they are different. Make the initial reply match the final reply which says "top-repos suite".